### PR TITLE
Add Bundler and Foreman

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem "github-pages"
 gem "compass"
+gem "foreman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,12 @@ GEM
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
       sass (~> 3.1)
+    dotenv (0.9.0)
     fast-stemmer (1.0.2)
     ffi (1.9.3)
+    foreman (0.63.0)
+      dotenv (>= 0.7)
+      thor (>= 0.13.6)
     fssm (0.2.10)
     github-pages (11)
       RedCloth (= 4.2.9)
@@ -56,6 +60,7 @@ GEM
     safe_yaml (0.9.7)
     sass (3.2.12)
     syntax (1.1.0)
+    thor (0.18.1)
     yajl-ruby (1.1.0)
 
 PLATFORMS
@@ -63,4 +68,5 @@ PLATFORMS
 
 DEPENDENCIES
   compass
+  foreman
   github-pages

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+jekyll: bundle exec jekyll build -w
+compass: bundle exec compass watch

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,1 @@
-copyright: 2011 - 2014 Cowork Niagara Co-operative Inc. All rights reserved.exclude:  - "Gemfile"  - "Gemfile.lock"
+copyright: 2011 - 2014 Cowork Niagara Co-operative Inc. All rights reserved.exclude:  - "Gemfile"  - "Gemfile.lock"  - "Procfile"


### PR DESCRIPTION
I've added support for Bundler and Foreman.

Bundler will allow us to declare our Ruby dependencies in the `Gemfile` - in this case, I've declared `github-pages` and `compass`.

Foreman will allow us to start up the development process through a single command - which will run both applications inside the same terminal window. I've defined `jekyll build` and `compass watch` inside the `Procfile`.
