### PR TITLE
Remove outdated information

### DIFF
--- a/source/about.html.erb
+++ b/source/about.html.erb
@@ -257,7 +257,7 @@ directory_index: false
     events. We organize educational, interactive, fun free and members-only events
     and meet-ups for entrepreneurs in the marketing, sales, web and software
     development industries. Whether it’s a Hamilton-Niagara Drupal group meet-up,
-    DevTricks (for developers), WriteTricks (for writers), a Sales Crafting
+    WriteTricks (for writers), a Sales Crafting
     meeting or one of our many others, you can find or create your niche.
   </p>
 </div>

--- a/source/events.html.erb
+++ b/source/events.html.erb
@@ -23,69 +23,6 @@ directory_index: false
 
 
   <h2>Regular Events</h2>
-  <div class="event">
-    <a href="http://www.eventbrite.ca/e/openhack-tickets-18896869044" target="_new" class="event-logo">
-      <img src="/images/events/openhack.png" alt="OpenHackSTC">
-    </a>
-
-    <div class="event-details">
-      <h3>OpenHackSTC</h3>
-      <dl>
-        <dt>Website</dt>
-        <dd><a href="http://openhack.github.io/st_catharines/" target="_new">Website</a></dd>
-
-        <dt>When</dt>
-        <dd>Not currently active</dd>
-
-        <dt>Admission</dt>
-        <dd>FREE</dd>
-
-        <dt>RSVP Required?</dt>
-        <dd><a href="http://www.eventbrite.ca/e/openhack-tickets-18896869044" target="_new">Yes please!</a></dd>
-      </dl>
-
-      <p>
-        Want to chat after DevTricks but never have the availability?
-        Want to beat the solitary blues?
-        Have a software hurdle and need some feedback?
-        Want to build something with others?
-        This event's for you!
-        Join other local Niagara software developers for some casual code,
-        beverages, and discussion. We have a welcoming group and all skill levels
-        / technologies are encouraged to attend.
-      </p>
-    </div>
-  </div>
-
-  <div class="event">
-    <a href="http://www.softwareniagara.com/" target="_new" class="event-logo">
-      <img src="/images/events/devtricks.png" alt="DevTricks">
-    </a>
-
-    <div class="event-details">
-      <h3>DevTricks</h3>
-      <dl>
-        <dt>Website</dt>
-        <dd><a href="http://www.softwareniagara.com/" target="_new">softwareniagara.com</a></dd>
-
-        <dt>When</dt>
-        <dd>Second Monday of each month at 7 p.m.</dd>
-
-        <dt>Admission</dt>
-        <dd>FREE</dd>
-
-        <dt>RSVP Required?</dt>
-        <dd><a href="http://www.meetup.com/software-niagara/" target="_new">Yes please!</a></dd>
-      </dl>
-
-      <p>
-        This event is organized by Software Niagara and hosted in partnership with
-        Cowork Niagara. We line up a few developers for each event to teach the
-        programming languages, frameworks, tools &amp; tips that make them productive.
-        DevTricks is open to everyone – members and non-members.
-      </p>
-    </div>
-  </div>
 
   <div class="event">
     <div class="event-logo">

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -57,12 +57,10 @@ title: Welcome to Niagara's First Coworking Community
       </p>
     </div>
     <ul class="events-list">
-      <li class="devtricks">DevTricks: 2nd Mondays</li>
       <li class="biztricks">BizTricks: 2nd Wednesdays</li>
       <li class="unstuck">Unstuck: Last Thursday of each month</li>
       <li class="writetricks">WriteTricks: 3rd Thursday</li>
       <li class="podtricks">PodTricks: 1st Thursday</li>
-      <li class="openhack">OpenHack: 4th Monday</li>
     </ul>
   </div>
 </div>

--- a/source/join.html.erb
+++ b/source/join.html.erb
@@ -112,7 +112,7 @@ directory_index: false
       focused events. We organize educational, interactive, fun free and
       members-only events and meet-ups for entrepreneurs in the marketing,
       sales, web and software development industries. Whether it’s a
-      Hamilton-Niagara Drupal group meet-up, DevTricks (for developers),
+      Hamilton-Niagara Drupal group meet-up,
       WriteTricks (for writers), a Sales Crafting meeting or one of our
       many others, you can find or create your niche.
     </p>

--- a/source/stylesheets/all.css.scss
+++ b/source/stylesheets/all.css.scss
@@ -143,9 +143,6 @@ body.index {
       @include hide-text();
       background-size: cover !important;
     }
-    .devtricks {
-      background: transparent url('../images/events/devtricks.png') no-repeat center center;
-    }
     .biztricks {
       background: transparent url('../images/events/biztricks.png') no-repeat center center;
     }
@@ -157,9 +154,6 @@ body.index {
     }
     .podtricks {
       background: transparent url('../images/events/podtricks.png') no-repeat center center;
-    }
-    .openhack {
-      background: transparent url('../images/events/openhack.png') no-repeat center center;
     }
   }
 }


### PR DESCRIPTION
This update removes out of date information about DevTricks and OpenHackSTC from the site.